### PR TITLE
cleanup the update site and the feature

### DIFF
--- a/workspace/com.dell.research.bc.eth.solidity.editor.feature/feature.xml
+++ b/workspace/com.dell.research.bc.eth.solidity.editor.feature/feature.xml
@@ -21,30 +21,6 @@
  *******************************************************************************/
    </copyright>
 
-   <includes
-         id="org.eclipse.xtext.runtime"
-         version="0.0.0"/>
-
-   <includes
-         id="org.eclipse.xtext.ui"
-         version="0.0.0"/>
-
-   <includes
-         id="org.eclipse.xtext.xbase"
-         version="0.0.0"/>
-
-   <includes
-         id="org.eclipse.xtext.xbase.lib"
-         version="0.0.0"/>
-
-   <includes
-         id="org.eclipse.xtext.xtext.ui"
-         version="0.0.0"/>
-
-   <includes
-         id="org.eclipse.xtend.sdk"
-         version="0.0.0"/>
-
    <requires>
       <import plugin="org.eclipse.xtext"/>
       <import plugin="org.eclipse.xtext.util"/>
@@ -53,9 +29,7 @@
       <import plugin="org.antlr.runtime"/>
       <import plugin="org.eclipse.xtext.common.types"/>
       <import plugin="org.eclipse.equinox.common"/>
-      <import feature="org.eclipse.xtext.xbase.lib" version="2.8.4.v201508050135" match="greaterOrEqual"/>
       <import plugin="org.apache.log4j"/>
-      <import feature="org.eclipse.xtext.ui" version="2.8.4.v201508050135"/>
       <import plugin="org.eclipse.ui.editors" version="3.5.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.ui.ide" version="3.5.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.xtext.ui.shared"/>
@@ -64,17 +38,9 @@
       <import plugin="org.eclipse.xtext.common.types.ui"/>
       <import plugin="org.eclipse.xtext.ui.codetemplates.ui"/>
       <import plugin="org.eclipse.compare"/>
+      <import feature="org.eclipse.xtext.ui" version="2.8.4.v201508050135" match="greaterOrEqual"/>
       <import feature="org.eclipse.xtext.xbase.lib" version="2.8.4.v201508050135" match="greaterOrEqual"/>
-      <import feature="org.eclipse.xtext.ui" version="2.8.4.v201508050135"/>
-      <import feature="org.eclipse.xtext.xbase.lib" version="2.8.4.v201508050135" match="greaterOrEqual"/>
-      <import feature="org.eclipse.xtext.ui" version="2.8.4.v201508050135"/>
-      <import feature="org.eclipse.xtext.xbase.lib" version="2.8.4.v201508050135" match="greaterOrEqual"/>
-      <import feature="org.eclipse.xtext.ui" version="2.8.4.v201508050135"/>
-      <import feature="org.eclipse.xtext.xbase.lib" version="2.8.4.v201508050135" match="greaterOrEqual"/>
-      <import feature="org.eclipse.xtext.ui" version="2.8.4.v201508050135"/>
-      <import feature="org.eclipse.xtext.ui" version="2.8.4.v201508050135"/>
-      <import feature="org.eclipse.xtext.xbase.lib" version="2.8.4.v201508050135" match="greaterOrEqual"/>
-      <import feature="org.eclipse.xtend.sdk" version="2.8.4.v201508050135"/>
+      <import feature="org.eclipse.xtend.sdk" version="2.8.4.v201508050135" match="greaterOrEqual"/>
    </requires>
 
    <plugin

--- a/workspace/com.dell.research.bc.eth.solidity.editor.target/com.dell.research.bc.eth.solidity.editor.target.target
+++ b/workspace/com.dell.research.bc.eth.solidity.editor.target/com.dell.research.bc.eth.solidity.editor.target.target
@@ -8,7 +8,7 @@
 <unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.e4.rcp.feature.group" version="0.0.0"/>
-<repository id="eclipse-luna" location="http://download.eclipse.org/releases/luna/"/>
+<repository id="eclipse-luna" location="http://download.eclipse.org/releases/mars/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
 <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>


### PR DESCRIPTION
Removed the included features, as there are already imported and there is no need to distribute them with the plugin, p2 will manage these dependencies for us and the user.  

This reduced the size of the resulting updatesite from about 25mb to 2,5mb.
- update the target platform to mars
