### PR TITLE
Fix import

### DIFF
--- a/workspace/com.dell.research.bc.eth.solidity.editor.tests/src/com/dell/research/bc/eth/solidity/editor/tests/ImportDirectiveTest.xtend
+++ b/workspace/com.dell.research.bc.eth.solidity.editor.tests/src/com/dell/research/bc/eth/solidity/editor/tests/ImportDirectiveTest.xtend
@@ -33,13 +33,46 @@ class ImportDirectiveTest  extends AbsSolidityUnitTest {
         import "«IMPORT_URL_1»" ;
     '''
 
+    val VALID_IMPORT1 = '''
+        import * as x from "«IMPORT_URL_1»" ;
+    '''
+
+    val VALID_IMPORT2 = '''
+        import {a as b, c as d} from "«IMPORT_URL_1»" ;
+    '''
+
     @Test
     def void givenValidImportDirective_thenNoErrors() {
         VALID_IMPORT.parse.assertNoErrors
+        VALID_IMPORT1.parse.assertNoErrors
+        VALID_IMPORT2.parse.assertNoErrors
     }
 
     @Test
     def void givenValidImportDirective_thenParsedURLIsCorrect() {
         Assert::assertEquals(IMPORT_URL_1, VALID_IMPORT.parse.importDirective.last.url);
     }
+    
+    @Test
+    def void givenValidImportDirective1_thenParsedURLIsCorrect() {
+        Assert::assertEquals(IMPORT_URL_1, VALID_IMPORT1.parse.importDirective.last.url);
+    }
+    
+    @Test
+    def void givenValidImportDirective1_thenParsedUnitAliasCorrect() {
+        Assert::assertEquals("x", VALID_IMPORT1.parse.importDirective.last.unitAlias);
+    }
+    
+    @Test
+    def void givenValidImportDirective2_thenParsedURLIsCorrect() {
+        Assert::assertEquals(IMPORT_URL_1, VALID_IMPORT2.parse.importDirective.last.url);
+    }
+    
+    @Test
+    def void givenValidImportDirective2_thenParsedSymbolAliasCorrect() {
+        Assert::assertEquals(2, VALID_IMPORT2.parse.importDirective.last.symbolAliases.size);
+        Assert::assertEquals("a", VALID_IMPORT2.parse.importDirective.last.symbolAliases.get(0).symbol);
+        Assert::assertEquals("b", VALID_IMPORT2.parse.importDirective.last.symbolAliases.get(0).alias);
+    }
+    
 } // ImportDirectiveTest

--- a/workspace/com.dell.research.bc.eth.solidity.editor.tests/src/com/dell/research/bc/eth/solidity/editor/tests/ImportDirectiveTest.xtend
+++ b/workspace/com.dell.research.bc.eth.solidity.editor.tests/src/com/dell/research/bc/eth/solidity/editor/tests/ImportDirectiveTest.xtend
@@ -50,12 +50,12 @@ class ImportDirectiveTest  extends AbsSolidityUnitTest {
 
     @Test
     def void givenValidImportDirective_thenParsedURLIsCorrect() {
-        Assert::assertEquals(IMPORT_URL_1, VALID_IMPORT.parse.importDirective.last.url);
+        Assert::assertEquals(IMPORT_URL_1, VALID_IMPORT.parse.importDirective.last.importURI);
     }
     
     @Test
     def void givenValidImportDirective1_thenParsedURLIsCorrect() {
-        Assert::assertEquals(IMPORT_URL_1, VALID_IMPORT1.parse.importDirective.last.url);
+        Assert::assertEquals(IMPORT_URL_1, VALID_IMPORT1.parse.importDirective.last.importURI);
     }
     
     @Test
@@ -65,7 +65,7 @@ class ImportDirectiveTest  extends AbsSolidityUnitTest {
     
     @Test
     def void givenValidImportDirective2_thenParsedURLIsCorrect() {
-        Assert::assertEquals(IMPORT_URL_1, VALID_IMPORT2.parse.importDirective.last.url);
+        Assert::assertEquals(IMPORT_URL_1, VALID_IMPORT2.parse.importDirective.last.importURI);
     }
     
     @Test

--- a/workspace/com.dell.research.bc.eth.solidity.editor.ui/src/com/dell/research/bc/eth/solidity/editor/ui/labeling/SolidityLabelProvider.xtend
+++ b/workspace/com.dell.research.bc.eth.solidity.editor.ui/src/com/dell/research/bc/eth/solidity/editor/ui/labeling/SolidityLabelProvider.xtend
@@ -58,7 +58,7 @@ class SolidityLabelProvider extends DefaultEObjectLabelProvider {
 // Look at pages 225-227 of the Xtext book on how to use
 // StyledStrings to produce a more attractive outline view 
     def text(ImportDirective id) {
-        id.url
+        id.importURI
     }
 
     def text(Contract cd) {

--- a/workspace/com.dell.research.bc.eth.solidity.editor/src/com/dell/research/bc/eth/solidity/editor/Solidity.xtext
+++ b/workspace/com.dell.research.bc.eth.solidity.editor/src/com/dell/research/bc/eth/solidity/editor/Solidity.xtext
@@ -26,9 +26,9 @@ Solidity:
     library+=Library)*;
 
 ImportDirective:
-    "import" url=STRING ";" | 
-    "import" "*" "as" unitAlias=ID "from" url=STRING ";" |
-    "import" "{" symbolAliases+=SymbolAlias ("," symbolAliases+=SymbolAlias)?  "}" "from" url=STRING ";"    
+    "import" importURI=STRING ";" | 
+    "import" "*" "as" unitAlias=ID "from" importURI=STRING ";" |
+    "import" "{" symbolAliases+=SymbolAlias ("," symbolAliases+=SymbolAlias)?  "}" "from" importURI=STRING ";"    
     ; 
     
 SymbolAlias:

--- a/workspace/com.dell.research.bc.eth.solidity.editor/src/com/dell/research/bc/eth/solidity/editor/Solidity.xtext
+++ b/workspace/com.dell.research.bc.eth.solidity.editor/src/com/dell/research/bc/eth/solidity/editor/Solidity.xtext
@@ -26,7 +26,14 @@ Solidity:
     library+=Library)*;
 
 ImportDirective:
-    "import" url=STRING ";";
+    "import" url=STRING ";" | 
+    "import" "*" "as" unitAlias=ID "from" url=STRING ";" |
+    "import" "{" symbolAliases+=SymbolAlias ("," symbolAliases+=SymbolAlias)?  "}" "from" url=STRING ";"    
+    ; 
+    
+SymbolAlias:
+	symbol=ID "as" alias=ID
+;
 
 ContractOrLibrary:
     Contract |


### PR DESCRIPTION
Add two other import options: 

```
import * as x from "url";    
import {a as b, c as d} from "url" ;
```

Changed the import property url to importURI. Hopefully this can be used to filter the scope later on.

I'm not sure if this is the elegant solution, the ImportDirective look a bit messy to me now. (Lack of experience maybe.)
