### PR TITLE
Fixed ePackage literal problem

### DIFF
--- a/workspace/com.dell.research.bc.eth.solidity.editor.ui/src/com/dell/research/bc/eth/solidity/editor/ui/outline/SolidityOutlineTreeProvider.xtend
+++ b/workspace/com.dell.research.bc.eth.solidity.editor.ui/src/com/dell/research/bc/eth/solidity/editor/ui/outline/SolidityOutlineTreeProvider.xtend
@@ -44,7 +44,7 @@ class SolidityOutlineTreeProvider extends DefaultOutlineTreeProvider {
     def protected _createChildren(DocumentRootNode parentNode, Solidity solidity) {
 
         if (solidity.importDirective.size > 0) {
-            createEStructuralFeatureNode(parentNode, solidity, SolidityPackage.Literals.SOLIDITY__IMPORT_DIRECTIVE,
+            createEStructuralFeatureNode(parentNode, solidity, SolidityPackage.eINSTANCE.solidity_ImportDirective,
             imageHelper.getImage("impc_obj.png"), "import declarations", false);
         }
 


### PR DESCRIPTION
I found the basic problem, we are exceeding a  magical number of elements in our grammar model.
See https://www.eclipse.org/forums/index.php/t/227347/ for details. 
The fix is not to use the Literals interface and access the eClasses and features via eInstance. The only usage is in the SolidityOutlineTreeProvider. So right now it is a good moment to change this.

This is Ed Merks statements:

> GenPackage has a "Literals Interface" property that's set to false by default for very large models (to avoid exceeding byte code limits). Initialize by Loading it similarly set to true for large models, again, to avoid exceeding byte code limits.

From: https://www.eclipse.org/forums/index.php/t/154047/
