### PR TITLE
Add new proposals.

### DIFF
--- a/workspace/com.dell.research.bc.eth.solidity.editor.ui/src/com/dell/research/bc/eth/solidity/editor/ui/contentassist/SolidityProposalProvider.xtend
+++ b/workspace/com.dell.research.bc.eth.solidity.editor.ui/src/com/dell/research/bc/eth/solidity/editor/ui/contentassist/SolidityProposalProvider.xtend
@@ -7,15 +7,39 @@
  * 
  * Contributors:
  *     Daniel Ford, Dell Corporation - initial API and implementation
+ *     Urs Zeidler
  *******************************************************************************/
 package com.dell.research.bc.eth.solidity.editor.ui.contentassist
 
 import com.dell.research.bc.eth.solidity.editor.SolidityUtil
+import com.dell.research.bc.eth.solidity.editor.solidity.Block
+import com.dell.research.bc.eth.solidity.editor.solidity.Contract
 import com.dell.research.bc.eth.solidity.editor.solidity.ContractOrLibrary
-import com.dell.research.bc.eth.solidity.editor.solidity.SpecialVariables
+import com.dell.research.bc.eth.solidity.editor.solidity.ElementaryType
+import com.dell.research.bc.eth.solidity.editor.solidity.EnumDefinition
+import com.dell.research.bc.eth.solidity.editor.solidity.Expression
+import com.dell.research.bc.eth.solidity.editor.solidity.ExpressionStatement
+import com.dell.research.bc.eth.solidity.editor.solidity.ForStatement
+import com.dell.research.bc.eth.solidity.editor.solidity.FunctionCallListArguments
+import com.dell.research.bc.eth.solidity.editor.solidity.FunctionDefinition
+import com.dell.research.bc.eth.solidity.editor.solidity.Index
+import com.dell.research.bc.eth.solidity.editor.solidity.Library
+import com.dell.research.bc.eth.solidity.editor.solidity.Mapping
 import com.dell.research.bc.eth.solidity.editor.solidity.QualifiedIdentifier
+import com.dell.research.bc.eth.solidity.editor.solidity.Solidity
+import com.dell.research.bc.eth.solidity.editor.solidity.SpecialExpression
+import com.dell.research.bc.eth.solidity.editor.solidity.SpecialVariables
 import com.dell.research.bc.eth.solidity.editor.solidity.StandardVariableDeclaration
+import com.dell.research.bc.eth.solidity.editor.solidity.Statement
+import com.dell.research.bc.eth.solidity.editor.solidity.StructDefinition
+import com.dell.research.bc.eth.solidity.editor.solidity.VarVariableDeclaration
+import com.dell.research.bc.eth.solidity.editor.solidity.Variable
+import com.dell.research.bc.eth.solidity.editor.solidity.VariableDeclarationExpression
+import java.util.ArrayList
+import java.util.Collection
 import java.util.HashSet
+import java.util.Iterator
+import java.util.List
 import org.eclipse.emf.ecore.EObject
 import org.eclipse.xtext.Assignment
 import org.eclipse.xtext.RuleCall
@@ -25,7 +49,6 @@ import org.eclipse.xtext.ui.editor.contentassist.ICompletionProposalAcceptor
 import static com.dell.research.bc.eth.solidity.editor.SolidityUtil.*
 
 import static extension org.eclipse.xtext.EcoreUtil2.*
-import com.dell.research.bc.eth.solidity.editor.solidity.SpecialExpression
 
 /**
  * See https://www.eclipse.org/Xtext/documentation/304_ide_concepts.html#content-assist
@@ -33,110 +56,131 @@ import com.dell.research.bc.eth.solidity.editor.solidity.SpecialExpression
  */
 class SolidityProposalProvider extends AbstractSolidityProposalProvider {
 
+	static final String IMG_LOCAL_VAR = 'localvariable_obj.png';
+	static final String IMG_PUBLIC_FIELD = 'field_public_obj.png'
+	static final String IMG_PUBLIC_METHOD = 'methpub_obj.png'
+
+	override complete_PrimaryExpression(EObject model, RuleCall ruleCall, ContentAssistContext context,
+		ICompletionProposalAcceptor acceptor) {
+		if (model instanceof FunctionCallListArguments) {
+			complete_Arguments(model, ruleCall, context, acceptor)
+			return;
+		} else if (model instanceof Index) {
+			complete_Index(model, ruleCall, context, acceptor)
+			return;
+		}
+		println("complete_PrimaryExpression:" + model + "::" + context.prefix)
+
+		fillAllPossibleProposals(model, acceptor, context, context.prefix, false)
+	}
+
+	override complete_Assignment(EObject model, RuleCall ruleCall, ContentAssistContext context,
+		ICompletionProposalAcceptor acceptor) {
+
+		if (!( model instanceof com.dell.research.bc.eth.solidity.editor.solidity.Assignment))
+			return;
+
+		println("complete_Assignment:" + model + "::" + context.prefix)
+		fillAllPossibleProposals(model, acceptor, context, context.prefix, false)
+	}
+
+	override complete_Comparison(EObject model, RuleCall ruleCall, ContentAssistContext context,
+		ICompletionProposalAcceptor acceptor) {
+
+		if (!( model instanceof Expression))
+			return;
+
+		println("complete_Comparison:" + model + "::" + context.prefix)
+		fillAllPossibleProposals(model, acceptor, context, context.prefix, false)
+	}
+
+	override complete_Arguments(EObject model, RuleCall ruleCall, ContentAssistContext context,
+		ICompletionProposalAcceptor acceptor) {
+
+		if (!(model instanceof FunctionCallListArguments))
+			return;
+		println("complete_Arguments:" + model + "::" + context.prefix)
+		val b = model.getContainerOfType(Block)
+		val allLocals = getAllValidLocalStatements(b, model.getContainerOfType(Statement))
+
+		fillAllLocalVariables(allLocals, acceptor, context, context.prefix, IMG_LOCAL_VAR)
+		fillAllParameters(model, acceptor, context, context.prefix)
+		fillAllFieldsAndMethods(model, acceptor, context, context.prefix)
+	}
+
 	override complete_StandardTypeWithoutQualifiedIdentifier(EObject model, RuleCall ruleCall,
 		ContentAssistContext context, ICompletionProposalAcceptor acceptor) {
-		fillAllFieldsAndMethods(model, acceptor, context, "")
+		println("complete_StandardTypeWithoutQualifiedIdentifier:" + model + "::" + context.prefix)
+
+		fillAllPossibleProposals(model, acceptor, context, context.prefix, true)
 	}
 
-	override completeQualifiedIdentifier_Qualifiers(EObject model, Assignment assignment, ContentAssistContext context, ICompletionProposalAcceptor acceptor) {
-		var type1 = model as QualifiedIdentifier
-		val fieldname = type1.identifier
-		
-		val allAllField = getAllFields(model)
-		val foundfield =  allAllField.findFirst[
-			it.variable.name.equals(fieldname)
-		]
-		if(foundfield==null) return
-		var qi = foundfield.type as QualifiedIdentifier
-		val typename = qi.identifier;
-		var type = model.resourceSet.allContents.filter(ContractOrLibrary).findFirst[
-			it.name.equals(typename)			
-		]
-		
-		fillAllFieldsAndMethods(type, acceptor, context, ".")		
-	}
-
-	private def completeThisExpression_FieldOrMethod(EObject model, Assignment assignment, ContentAssistContext context,
+	override complete_Index(EObject model, RuleCall ruleCall, ContentAssistContext context,
 		ICompletionProposalAcceptor acceptor) {
-		fillAllFieldsAndMethods(model, acceptor, context, ".")
-	}
 
-	private def getAllFields(EObject model) {
-		var cl = model.getContainerOfType(ContractOrLibrary)
-		var ch = classHierarchy(cl)
+		if (!(model instanceof Index))
+			return;
 
-		val allAllField = new HashSet
-		allAllField.addAll(cl.body.variables.filter(StandardVariableDeclaration))
-		ch.forEach [
-			allAllField.addAll(it.body.variables.filter(StandardVariableDeclaration).filter[!isPrivate(it)])
-		]
-		
-		allAllField
-	}
-
-
-	private def fillAllFieldsAndMethods(EObject model, ICompletionProposalAcceptor acceptor,
-		ContentAssistContext context, String matchingPrefix) {
-		var cl = model.getContainerOfType(ContractOrLibrary)
-		var ch = classHierarchy(cl)
-
-		val allAllField = new HashSet
-		val allMethods = new HashSet
-
-		allAllField.addAll(cl.body.variables.filter(StandardVariableDeclaration))
-		allMethods.addAll(cl.body.functions)
-		ch.forEach [
-			allAllField.addAll(it.body.variables.filter(StandardVariableDeclaration).filter[!isPrivate(it)])
-			allMethods.addAll(it.body.functions.filter[!isPrivate(it)])
-		]
-
-		allAllField.forEach [
-			acceptor.accept(
-				createCompletionProposal(matchingPrefix + it.variable.name, labelProvider.getText(it.variable),
-					labelProvider.getImage(it), context));
-		]
-		allMethods.forEach [
-			acceptor.accept(
-				createCompletionProposal(matchingPrefix + it.name + "()", labelProvider.getText(it),
-					labelProvider.getImage(it), context));
-		]
-	}
-
-	private def completeSuperExpression_FieldOrMethod(EObject model, Assignment assignment, ContentAssistContext context,
-		ICompletionProposalAcceptor acceptor) {
-		var cl = model.getContainerOfType(ContractOrLibrary)
-		var ch = classHierarchy(cl)
-
-		val allAllField = new HashSet
-		val allMethods = new HashSet
-
-		ch.forEach [
-			allAllField.addAll(it.body.variables.filter(StandardVariableDeclaration))
-			allMethods.addAll(it.body.functions)
-		]
-
-		allAllField.forEach [
-			acceptor.accept(
-				createCompletionProposal("." + it.variable.name, labelProvider.getText(it.variable),
-					labelProvider.getImage(it), context));
-		]
-		allMethods.forEach [
-			acceptor.accept(
-				createCompletionProposal("." + it.name, labelProvider.getText(it), labelProvider.getImage(it),
-					context));
-			]
+		println("complete_Index:" + model + "::" + context.prefix)
+		fillAllFieldsAndMethods(model, acceptor, context, context.prefix)
+		var b = model.getContainerOfType(Block)
+		if (b != null) {
+			fillAllLocalVariables(b.statements, acceptor, context, context.prefix, IMG_LOCAL_VAR)
+			fillAllParameters(model, acceptor, context, context.prefix)
 		}
-
-	override completeSpecialExpression_FieldOrMethod(EObject model, Assignment assignment, ContentAssistContext context, ICompletionProposalAcceptor acceptor) {
-		switch ((model as SpecialExpression).type) {
-				case SUPER: completeSuperExpression_FieldOrMethod(model,assignment,context,acceptor)
-				case THIS: completeThisExpression_FieldOrMethod(model,assignment,context,acceptor)
-			}
 	}
 
+	override completeQualifiedIdentifier_Qualifiers(EObject model, Assignment assignment, ContentAssistContext context,
+		ICompletionProposalAcceptor acceptor) {
+
+		println("completeQualifiedIdentifier_Qualifiers:" + model + "::" + context.prefix)
+		if (!hasQualifier(context.prefix))
+			return;
+		if (model instanceof QualifiedIdentifier) {
+			var type1 = model as QualifiedIdentifier
+			var index = type1.qualifiers.indexOf(context.previousModel)
+			if (index > 0) { // the case qi.q1.q2...qn
+			// TODO: resolve the complete type 
+				return
+			}
+
+			val fieldname = type1.identifier
+			var t = resolveType(fieldname, model)
+			if(t == null) t = resolveTypename(fieldname, model)
+
+			if (t instanceof Mapping) {
+				var m = t as Mapping
+				var mt = m.valueType
+				completeQualifiedIdentifier_Qualifiers(mt, assignment, context, acceptor)
+			} else if (t != null) {
+				fillForResolvedType(t, acceptor, context, context.prefix)
+			}
+		}
+	}
+
+	override completeDefinitionBody_Variables(EObject model, Assignment assignment, ContentAssistContext context,
+		ICompletionProposalAcceptor acceptor) {
+		println("completeDefinitionBody_Variables:" + model + "::" + context.prefix)
+
+		val c = getAllAccesibleContractsOrLibraries(model)
+		fillTypes(c, acceptor, context)
+		fillAllInnerTypes(model, acceptor, context, false, context.prefix)
+	}
+
+	override completeSpecialExpression_FieldOrMethod(EObject model, Assignment assignment, ContentAssistContext context,
+		ICompletionProposalAcceptor acceptor) {
+		println("completeSpecialExpression_FieldOrMethod:" + model + "::" + context.prefix)
+
+		switch ((model as SpecialExpression).type) {
+			case SUPER: completeSuperExpression_FieldOrMethod(model, assignment, context, acceptor)
+			case THIS: completeThisExpression_FieldOrMethod(model, assignment, context, acceptor)
+		}
+	}
 
 	override completeSpecialVariables_Field(EObject model, Assignment assignment, ContentAssistContext context,
 		ICompletionProposalAcceptor acceptor) {
+		println("completeSpecialVariables_Field:" + model + "::" + context.prefix)
+
 		switch ((model as SpecialVariables).type) {
 			case MSG:
 				SolidityUtil.MESSAGE_MEMBERS.forEach [
@@ -152,5 +196,424 @@ class SolidityProposalProvider extends AbstractSolidityProposalProvider {
 				]
 		}
 	}
+
+	/**
+	 * Check if the last qualifier is a dot.
+	 */
+	private def hasQualifier(String prefix) {
+		return prefix.equals(".")
+	}
+
+	/**
+	 * Returns the type of an given identifier or typename.
+	 */
+	private def resolveType(String identifier, EObject model) {
+		val fields = getAllFields(model)
+		val foundfield = fields.findFirst [
+			it.variable?.name.equals(identifier)
+		]
+
+		var t = foundfield?.type
+
+		if (t == null) { // check for a local variable
+			var b = model.getContainerOfType(Block)
+			var statement = model.getContainerOfType(Statement)
+			var allLocals = getAllValidLocalStatements(b, statement)
+
+			if (!allLocals.isEmpty) {
+				var tt = allLocals.filter(ExpressionStatement).filter [
+					(it.expression instanceof VariableDeclarationExpression) &&
+						((it.expression as VariableDeclarationExpression).type instanceof QualifiedIdentifier)
+				].findFirst [
+					(it.expression as VariableDeclarationExpression).variable?.name.equals(identifier)
+				]
+				if (tt != null)
+					t = (tt?.expression as VariableDeclarationExpression).type
+
+			}
+		}
+		if (t == null) { // check for a parameter
+			var epara = getAllParameters(model).filter(Variable).findFirst [
+				it.name.equals(identifier)
+			]
+			if (epara != null) {
+				if (epara.eContainer instanceof StandardVariableDeclaration) {
+					t = (epara.eContainer as StandardVariableDeclaration).type
+				}
+			}
+		}
+
+		if (t instanceof QualifiedIdentifier) {
+			var qi = t as QualifiedIdentifier
+			val typename = qi.identifier
+
+			return resolveTypename(typename, model)
+		} else if (t instanceof Mapping) {
+			return t
+		} else if (t instanceof ElementaryType) {
+			return t
+		}
+	}
+
+	private def resolveTypename(String typename, EObject model) {
+		var type = getAllAccesibleContractsOrLibraries(model).findFirst [
+			it.name.equals(typename)
+		]
+		if (type != null)
+			return type
+
+		var stype = getAllStructs(model).findFirst [
+			it.name.equals(typename)
+		]
+		if (stype != null)
+			return stype
+
+		var etype = getAllEnums(model).findFirst [
+			it.name.equals(typename)
+		]
+		if (etype != null)
+			return etype
+
+	}
+
+	/**
+	 * Fill all variables defined in the given block. 
+	 */
+	def private fillAllLocalVariables(Collection<? super Statement> statements, ICompletionProposalAcceptor acceptor,
+		ContentAssistContext context, String matchingPrefix, String imageUrl) {
+		var mp = matchingPrefix
+		if (!hasQualifier(mp))
+			mp = ""
+
+		val mpv = mp
+
+		val variableDeclaration = new HashSet<VariableDeclarationExpression>()
+		statements.filter(ExpressionStatement).filter [
+			it.expression instanceof VariableDeclarationExpression
+		].forEach [
+			variableDeclaration.add(it.expression as VariableDeclarationExpression)
+		]
+		val standardVariableDeclaration = new HashSet<StandardVariableDeclaration>()
+		statements.filter(StandardVariableDeclaration).forEach [
+			standardVariableDeclaration.add(it)
+		]
+		statements.filter(ForStatement).forEach [
+			if (it.initExpression instanceof StandardVariableDeclaration) {
+				standardVariableDeclaration.add(it.initExpression as StandardVariableDeclaration)
+			}
+		]
+		val varVariableDeclaration = new HashSet<VarVariableDeclaration>()
+		statements.filter(ExpressionStatement).filter [
+			it.expression instanceof VarVariableDeclaration
+		].forEach [
+			varVariableDeclaration.add(it.expression as VarVariableDeclaration)
+		]
+		variableDeclaration.forEach [
+			if ((it.variable != null && it.variable.name.startsWith(mpv)) || hasQualifier(matchingPrefix))
+				acceptor.accept(
+					createCompletionProposal(mpv + it.variable.name, labelProvider.getText(it),
+						labelProvider.getImage(imageUrl), context))
+		]
+		varVariableDeclaration.forEach [
+			if ((it.variable != null && it.variable.name.startsWith(mpv)) || hasQualifier(matchingPrefix))
+				acceptor.accept(
+					createCompletionProposal(mpv + it.variable.name, labelProvider.getText(it),
+						labelProvider.getImage(imageUrl), context))
+		]
+		standardVariableDeclaration.forEach [
+			if ((it.variable != null && it.variable.name.startsWith(mpv)) || hasQualifier(matchingPrefix))
+				acceptor.accept(
+					createCompletionProposal(mpv + it.variable.name, labelProvider.getText(it),
+						labelProvider.getImage(imageUrl), context))
+		]
+	}
+
+	/**
+	 * Fills all proposal types.
+	 */
+	private def fillAllPossibleProposals(EObject model, ICompletionProposalAcceptor acceptor,
+		ContentAssistContext context, String matchingPrefix, boolean includeTypes) {
+		var Block block = null
+		var Statement statement = null
+
+		if (model instanceof Block) {
+			var test = context.currentNode.parent.semanticElement
+			statement = test.getContainerOfType(Statement)
+			block = model as Block
+		} else if (model instanceof Statement) {
+			block = model.getContainerOfType(Block)
+			statement = findMatchingStatement(block, model)
+		} else if (model instanceof Expression) {
+			block = model.getContainerOfType(Block)
+			statement = model.getContainerOfType(Statement)
+		}
+
+		var allLocalVariables = getAllValidLocalStatements(block, statement)
+		fillAllLocalVariables(allLocalVariables, acceptor, context, context.prefix, IMG_LOCAL_VAR)
+
+		val c = getAllAccesibleContractsOrLibraries(model)
+		fillAllParameters(model, acceptor, context, context.prefix)
+		fillAllFieldsAndMethods(model, acceptor, context, context.prefix)
+		if (includeTypes) {
+			fillTypes(c, acceptor, context)
+			fillAllInnerTypes(model, acceptor, context, true, matchingPrefix)
+		}
+	}
+
+	/**
+	 * Search the next statement (parent) defined in the block. 
+	 */
+	private def Statement findMatchingStatement(Block block, EObject model) {
+		if (block.statements.indexOf(model) != -1)
+			return model as Statement
+		if(model.eContainer == null || model.eContainer instanceof Solidity) return null;
+
+		return findMatchingStatement(block, model.eContainer)
+	}
+
+	/**
+	 * Fills the proposal for the resolved type( the grammar type).
+	 */
+	private def fillForResolvedType(EObject t, ICompletionProposalAcceptor acceptor, ContentAssistContext context,
+		String matchingPrefix) {
+		var mp = matchingPrefix
+		if (!hasQualifier(mp))
+			mp = ""
+
+		val mpv = mp
+
+		if (t instanceof Contract) {
+			fillAllFieldsAndMethods(t, acceptor, context, matchingPrefix)
+		} else if (t instanceof Library) {
+			fillAllFieldsAndMethods(t, acceptor, context, matchingPrefix)
+		} else if (t instanceof StructDefinition) {
+			fillAllLocalVariables((t as StructDefinition).members, acceptor, context, matchingPrefix, IMG_PUBLIC_FIELD)
+		} else if (t instanceof EnumDefinition) {
+			(t as EnumDefinition).members.forEach [
+				if ((it.name != null && it.name.startsWith(mpv)) || hasQualifier(matchingPrefix))
+					acceptor.accept(
+						createCompletionProposal(mpv + it.name, labelProvider.getText(it), labelProvider.getImage(it),
+							context))
+			]
+		} else if (t instanceof ElementaryType) {
+			var e = (t as ElementaryType)
+			switch (e.name) {
+				case ADDRESS: {
+					SolidityUtil.ADDRESS_MEMBERS.forEach [
+						acceptor.accept(
+							createCompletionProposal(matchingPrefix + it, it, labelProvider.getImage(IMG_PUBLIC_METHOD),
+								context))
+					]
+				}
+				default: {
+				}
+			}
+		}
+	}
+
+	/**
+	 * Fills the types.
+	 */
+	def private fillTypes(Iterator<ContractOrLibrary> libraries, ICompletionProposalAcceptor acceptor,
+		ContentAssistContext context) {
+		libraries.forEach [
+			acceptor.accept(
+				createCompletionProposal(it.name, labelProvider.getText(it), labelProvider.getImage(it), context));
+		]
+	}
+
+	/**
+	 * Fills all the defined parameters.
+	 */
+	private def fillAllParameters(EObject model, ICompletionProposalAcceptor acceptor, ContentAssistContext context,
+		String matchingPrefix) {
+		val fd = model.getContainerOfType(FunctionDefinition)
+		fillAllLocalVariables(fd.parameters?.parameters, acceptor, context, matchingPrefix, IMG_LOCAL_VAR)
+
+		if (fd.returnParameters != null) {
+			var mp = matchingPrefix
+			if (!hasQualifier(mp))
+				mp = ""
+
+			val mpv = mp
+			fd.returnParameters?.parameters?.forEach [
+				if ((it.variable != null && it.variable.name.startsWith(mpv)) || hasQualifier(matchingPrefix))
+					acceptor.accept(
+						createCompletionProposal(matchingPrefix + it.variable.name, labelProvider.getText(it),
+							labelProvider.getImage(IMG_LOCAL_VAR), context))
+
+			]
+		}
+	}
+
+	/**
+	 * Add the inner types as proposal.
+	 */
+	private def fillAllInnerTypes(EObject model, ICompletionProposalAcceptor acceptor, ContentAssistContext context,
+		boolean includeEvents, String startText) {
+		val allStructs = getAllStructs(model)
+		val allEnums = getAllEnums(model)
+		val allEvents = getAllEvents(model)
+
+		var mp = startText
+		if (!hasQualifier(mp))
+			mp = ""
+
+		val mpv = mp
+
+		allStructs.forEach [
+			if (it.name.startsWith(mpv))
+				acceptor.accept(
+					createCompletionProposal(it.name, labelProvider.getText(it), labelProvider.getImage(it), context));
+		]
+		allEnums.forEach [
+			if (it.name.startsWith(mpv))
+				acceptor.accept(
+					createCompletionProposal(it.name, labelProvider.getText(it), labelProvider.getImage(it), context));
+		]
+		if (includeEvents) {
+			allEvents.forEach [
+				if (it.name.startsWith(mpv))
+					acceptor.accept(
+						createCompletionProposal(it.name, labelProvider.getText(it), labelProvider.getImage(it),
+							context));
+				]
+			}
+		}
+
+		/**
+		 * Add the inner types as proposal.
+		 */
+		private def fillAllInnerTypes(EObject model, ICompletionProposalAcceptor acceptor, ContentAssistContext context,
+			boolean includeEvents) {
+			val allStructs = getAllStructs(model)
+			val allEnums = getAllEnums(model)
+			val allEvents = getAllEvents(model)
+
+			allStructs.forEach [
+				acceptor.accept(
+					createCompletionProposal(it.name, labelProvider.getText(it), labelProvider.getImage(it), context));
+			]
+			allEnums.forEach [
+				acceptor.accept(
+					createCompletionProposal(it.name, labelProvider.getText(it), labelProvider.getImage(it), context));
+			]
+			if (includeEvents) {
+				allEvents.forEach [
+					acceptor.accept(
+						createCompletionProposal(it.name, labelProvider.getText(it), labelProvider.getImage(it),
+							context));
+					]
+				}
+			}
+
+			/**
+			 * Fills all the not private members of the ContractOrLibrary containing the model.
+			 */
+			private def fillAllFieldsAndMethods(EObject model, ICompletionProposalAcceptor acceptor,
+				ContentAssistContext context, String matchingPrefix) {
+				var cl = model.getContainerOfType(ContractOrLibrary)
+				var ch = classHierarchy(cl)
+
+				val allAllField = new HashSet
+				val allMethods = new HashSet
+
+				allAllField.addAll(cl.body?.variables.filter(StandardVariableDeclaration))
+				allMethods.addAll(cl.body?.functions)
+				ch.forEach [
+					allAllField.addAll(it.body?.variables.filter(StandardVariableDeclaration).filter[!isPrivate(it)])
+					allMethods.addAll(it.body?.functions.filter[!isPrivate(it)])
+				]
+
+				var mp = matchingPrefix
+				if (!hasQualifier(mp))
+					mp = ""
+
+				val mpv = mp
+
+				allAllField.forEach [
+					if ((it.variable != null && it.variable.name.startsWith(mpv)) || hasQualifier(matchingPrefix))
+						acceptor.accept(
+							createCompletionProposal(mpv + it.variable.name, labelProvider.getText(it),
+								labelProvider.getImage(it), context));
+				]
+				allMethods.forEach [
+					if ((it != null && it.name != null && it.name.startsWith(mpv)) || hasQualifier(matchingPrefix))
+						acceptor.accept(
+							createCompletionProposal(mpv + it.name + "()", labelProvider.getText(it),
+								labelProvider.getImage(it), context));
+				]
+			}
+
+			/**
+			 * Get all the local variables defined 
+			 */
+			private def Collection<? super Statement> getAllValidLocalStatements(Block s_block, Statement s_statement) {
+				var Block block = s_block
+				var Statement statement = s_statement
+				val List<? super Statement> r_statements = new ArrayList<Statement>
+
+				while (block != null) {
+					var index = block.statements.indexOf(statement)
+					var List<? super Statement> statements = new ArrayList(block.statements)
+					if (index != -1) {
+						statements = new ArrayList(block.statements.subList(0, index))
+					}
+					if (block.eContainer instanceof ForStatement) {
+						statements.add((block.eContainer as ForStatement))
+					}
+
+					statements.forEach [
+						r_statements.add(it as Statement)
+					]
+
+					var b1 = block.eContainer.getContainerOfType(Block)
+					if (b1 != null) { // move the blocks upward to collect the other lv
+						block = b1
+						statement = null
+					} else {
+						block = null;
+					}
+				}
+				return r_statements
+			}
+
+			/**
+			 * Added all fields and methods for the this expression.
+			 */
+			private def completeThisExpression_FieldOrMethod(EObject model, Assignment assignment,
+				ContentAssistContext context, ICompletionProposalAcceptor acceptor) {
+				fillAllFieldsAndMethods(model, acceptor, context, ".")
+			}
+
+			/**
+			 * Added the fields and methods for the super expression.
+			 */
+			private def completeSuperExpression_FieldOrMethod(EObject model, Assignment assignment,
+				ContentAssistContext context, ICompletionProposalAcceptor acceptor) {
+				var cl = model.getContainerOfType(ContractOrLibrary)
+				var ch = classHierarchy(cl)
+
+				val allAllField = new HashSet
+				val allMethods = new HashSet
+
+				ch.forEach [
+					if (it.body != null) {
+						allAllField.addAll(it.body.variables.filter(StandardVariableDeclaration))
+						allMethods.addAll(it.body.functions)
+					}
+				]
+
+				allAllField.forEach [
+					acceptor.accept(
+						createCompletionProposal("." + it.variable.name, labelProvider.getText(it.variable),
+							labelProvider.getImage(it), context));
+				]
+				allMethods.forEach [
+					acceptor.accept(
+						createCompletionProposal("." + it.name, labelProvider.getText(it), labelProvider.getImage(it),
+							context));
+				]
+			}
+		}
 		
-}

--- a/workspace/com.dell.research.bc.eth.solidity.editor.ui/src/com/dell/research/bc/eth/solidity/editor/ui/labeling/SolidityLabelProvider.xtend
+++ b/workspace/com.dell.research.bc.eth.solidity.editor.ui/src/com/dell/research/bc/eth/solidity/editor/ui/labeling/SolidityLabelProvider.xtend
@@ -10,10 +10,12 @@
  *******************************************************************************/
 package com.dell.research.bc.eth.solidity.editor.ui.labeling
 
+import com.dell.research.bc.eth.solidity.editor.SolidityUtil
 import com.dell.research.bc.eth.solidity.editor.solidity.Contract
 import com.dell.research.bc.eth.solidity.editor.solidity.ElementaryType
 import com.dell.research.bc.eth.solidity.editor.solidity.EnumDefinition
 import com.dell.research.bc.eth.solidity.editor.solidity.EnumValue
+import com.dell.research.bc.eth.solidity.editor.solidity.Event
 import com.dell.research.bc.eth.solidity.editor.solidity.FunctionDefinition
 import com.dell.research.bc.eth.solidity.editor.solidity.ImportDirective
 import com.dell.research.bc.eth.solidity.editor.solidity.Library
@@ -27,7 +29,8 @@ import com.dell.research.bc.eth.solidity.editor.solidity.Statement
 import com.dell.research.bc.eth.solidity.editor.solidity.StructDefinition
 import com.dell.research.bc.eth.solidity.editor.solidity.VarVariableDeclaration
 import com.dell.research.bc.eth.solidity.editor.solidity.VarVariableTupleVariableDeclaration
-import com.dell.research.bc.eth.solidity.editor.solidity.Event
+import com.dell.research.bc.eth.solidity.editor.solidity.VariableDeclarationExpression
+import com.dell.research.bc.eth.solidity.editor.solidity.VisibilityEnum
 import com.google.inject.Inject
 import org.eclipse.emf.edit.ui.provider.AdapterFactoryLabelProvider
 import org.eclipse.jface.viewers.StyledString
@@ -35,8 +38,6 @@ import org.eclipse.swt.SWT
 import org.eclipse.swt.graphics.RGB
 import org.eclipse.xtext.ui.editor.utils.TextStyle
 import org.eclipse.xtext.ui.label.DefaultEObjectLabelProvider
-import com.dell.research.bc.eth.solidity.editor.SolidityUtil
-import com.dell.research.bc.eth.solidity.editor.solidity.VisibilityEnum
 
 /**
  * Provides labels for EObjects.
@@ -107,11 +108,11 @@ class SolidityLabelProvider extends DefaultEObjectLabelProvider {
                 sb.append("(")
             }
             for (var int i = 0; i < rpl.parameters.size - 1; i++) {
-                sb.append(getText(rpl.parameters.get(i)))
+                sb.append(getText(rpl.parameters.get(i).typeRef))
                 sb.append(", ")
             }
             if (rpl.parameters.size >= 1) {
-                sb.append(getText(rpl.parameters.last()))
+                sb.append(getText(rpl.parameters.last().typeRef))
             }
             if (rpl.parameters.size > 1) {
                 sb.append(")")
@@ -121,8 +122,10 @@ class SolidityLabelProvider extends DefaultEObjectLabelProvider {
     }
 
     def text(ReturnParameterDeclaration rpd) {
-        val StringBuilder sb = new StringBuilder(getText(rpd.typeRef));
-        sb.toString
+        new StyledString(getText(rpd.variable)).append(new StyledString(
+            " : " + getText(rpd.typeRef),
+            StyledString::DECORATIONS_STYLER
+        ))
     }
 
     def text(Modifier md) {
@@ -146,6 +149,21 @@ class SolidityLabelProvider extends DefaultEObjectLabelProvider {
             StyledString::DECORATIONS_STYLER
         ))
     }
+
+    def text(VarVariableDeclaration svd) {
+        new StyledString(getText(svd.variable)).append(new StyledString(
+            " : " + getText(svd.varType),
+            StyledString::DECORATIONS_STYLER
+        ))
+    }
+
+    def text(VariableDeclarationExpression svd) {
+        new StyledString(getText(svd.variable)).append(new StyledString(
+            " : " + getText(svd.type),
+            StyledString::DECORATIONS_STYLER
+        ))
+    }
+
 
     def text(ElementaryType et) {
         et.name.toString
@@ -190,6 +208,10 @@ class SolidityLabelProvider extends DefaultEObjectLabelProvider {
 
     // Images (found in the "icons" folder
     // ---------------------------------------------------
+    def image(String image){
+    	image
+    }
+    
     def image(Event cd){
     	'event_obj.gif'
     }

--- a/workspace/com.dell.research.bc.eth.solidity.editor/src/com/dell/research/bc/eth/solidity/editor/SolidityUtil.xtend
+++ b/workspace/com.dell.research.bc.eth.solidity.editor/src/com/dell/research/bc/eth/solidity/editor/SolidityUtil.xtend
@@ -7,6 +7,7 @@
  * 
  * Contributors:
  *     Daniel Ford, Dell Corporation - initial API and implementation
+ * 	   Urs Zeidler
  *******************************************************************************/
 package com.dell.research.bc.eth.solidity.editor
 

--- a/workspace/com.dell.research.bc.eth.solidity.editor/src/com/dell/research/bc/eth/solidity/editor/SolidityUtil.xtend
+++ b/workspace/com.dell.research.bc.eth.solidity.editor/src/com/dell/research/bc/eth/solidity/editor/SolidityUtil.xtend
@@ -21,11 +21,14 @@ import com.dell.research.bc.eth.solidity.editor.solidity.StandardVariableDeclara
 import com.dell.research.bc.eth.solidity.editor.solidity.VisibilityEnum
 import com.dell.research.bc.eth.solidity.editor.solidity.VisibilitySpecifier
 import com.google.common.collect.Sets
+import java.util.Collection
 import java.util.Set
 import org.eclipse.emf.ecore.EObject
 
 import static extension org.eclipse.xtext.EcoreUtil2.*
-import java.util.Collection
+import java.util.HashSet
+import com.dell.research.bc.eth.solidity.editor.solidity.VariableDeclarationExpression
+import com.dell.research.bc.eth.solidity.editor.solidity.Variable
 
 // See page 202 of Xtext book
 class SolidityUtil {
@@ -34,6 +37,7 @@ class SolidityUtil {
 	public static Set<String> TRANSACTION_MEMBERS = Sets.newHashSet("gasprice", "origin")
 	public static Set<String> CURRENTBLOCK_MEMBERS = Sets.newHashSet("coinbase", "difficulty", "gaslimit", "number",
 		"blockhash", "timestamp")
+	public static Set<String> ADDRESS_MEMBERS = Sets.newHashSet("balance", "send")
 
 	def static containingSolidity(EObject e) {
 		e.getContainerOfType(typeof(Solidity))
@@ -94,20 +98,115 @@ class SolidityUtil {
 	def static toVisiblilityKind(FunctionDefinition fd) {
 		return toVisiblilityKind(fd.optionalElements.filter(VisibilitySpecifier).toList)
 	}
-	
+
 	def static toVisiblilityKind(StandardVariableDeclaration vd) {
 		return toVisiblilityKind(vd.optionalElements.filter(VisibilitySpecifier).toList)
 	}
 
 	/**
-	 * Not only returns the visibility kind. Public for default. 
+	 * Returns the visibility kind. Public for default. 
 	 */
 	def static toVisiblilityKind(Collection<VisibilitySpecifier> vs) {
-		if(vs.isEmpty)//public is the default
+		if (vs.isEmpty) // public is the default
 			return VisibilityEnum::PUBLIC
-			
+
 		return vs.get(0).visibility
 	}
 
+	/**
+	 * Returns all defined in and out parameters.
+	 */
+	def static Collection<Variable> getAllParameters(EObject model) {
+		val parameters = new HashSet
+
+		var fd = model.getContainerOfType(FunctionDefinition)
+		if (fd != null) {
+			fd.parameters?.parameters?.filter(VariableDeclarationExpression).forEach [
+				parameters.add(it.variable)
+			]
+			fd.parameters?.parameters?.filter(StandardVariableDeclaration).forEach [
+				parameters.add(it.variable)
+			]
+
+			fd.returnParameters?.parameters?.forEach [
+				parameters.add(it.variable)
+			]
+		}
+		return parameters
+	}
+
+	/**
+	 * Get all accessible contacts.  
+	 */
+	def static getAllAccesibleContractsOrLibraries(EObject model) {
+		model.resourceSet.allContents.filter(ContractOrLibrary)
+	// TODO: this need to be filtered by the import statements
+	}
+
+	/**
+	 * Returns all field defined by the type or the super types.
+	 */
+	def static getAllFields(EObject model) {
+		var cl = model.getContainerOfType(ContractOrLibrary)
+		var ch = classHierarchy(cl)
+
+		val allAllField = new HashSet
+		allAllField.addAll(cl.body.variables.filter(StandardVariableDeclaration))
+		ch.forEach [
+			if (it.body != null)
+				allAllField.addAll(it.body.variables.filter(StandardVariableDeclaration).filter[!isPrivate(it)])
+		]
+
+		allAllField
+	}
+
+	/**
+	 * Returns all structs defined by the type or the super types.
+	 */
+	def static getAllStructs(EObject model) {
+		var cl = model.getContainerOfType(ContractOrLibrary)
+		var ch = classHierarchy(cl)
+
+		val allStructs = new HashSet
+		allStructs.addAll(cl.body.structs)
+
+		ch.forEach [
+			if (it.body != null)
+				allStructs.addAll(it.body.structs)
+		]
+		allStructs
+	}
+
+	/**
+	 * Returns all enums defined by the type or the super types.
+	 */
+	def static getAllEnums(EObject model) {
+		var cl = model.getContainerOfType(ContractOrLibrary)
+		var ch = classHierarchy(cl)
+
+		val allEnums = new HashSet
+		allEnums.addAll(cl.body.enums)
+		ch.forEach [
+			if (it.body != null)
+				allEnums.addAll(it.body.enums)
+		]
+		allEnums
+	}
+
+	/**
+	 * Returns all events defined by the type or the super types.
+	 */
+	def static getAllEvents(EObject model) {
+		var cl = model.getContainerOfType(ContractOrLibrary)
+		var ch = classHierarchy(cl)
+
+		val allEvents = new HashSet
+		allEvents.addAll(cl.body.events)
+		ch.forEach [
+			if (it.body != null)
+				allEvents.addAll(it.body.events)
+		]
+		allEvents
+	}
 
 } // SolidityUtil


### PR DESCRIPTION
This adds proposals for:
- types in the field declaration
- all available types in a code block, in a method call and in arrays
  - all reachable methods
  - all reachable types (Contracts, Structs and Enums)
  - all reachable local variable in the block
  - parameters(in and out) defined by the function 
  - simple resolving of qualifiers, also resolving mapping value type
    - for a given variable or field 
      - the defined fields of the type
      - the defined methods of the type 
    - for an address type the two expressions "send" and "balance" 

It also fixed a classcast exception I introduce when the field is an ElementaryType. 

A complex qualifier, for example  a.b.c.d, will not be resolved by now.
